### PR TITLE
Update OLED_Z_Display_Driver_Test_Suite.ino

### DIFF
--- a/examples/OLED_Z_Display_Driver_Test_Suite/OLED_Z_Display_Driver_Test_Suite.ino
+++ b/examples/OLED_Z_Display_Driver_Test_Suite/OLED_Z_Display_Driver_Test_Suite.ino
@@ -2,7 +2,7 @@
 #include <SeeedOLED.h>
 #include <avr/pgmspace.h>
 
-static unsigned char SeeedLogo[] PROGMEM ={
+static const unsigned char SeeedLogo[] PROGMEM ={
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -142,18 +142,18 @@ void loop()
   setDisplayToOriginalState(4);
   
   SeeedOled.clearDisplay();               // clear the screen and set start position to top left corner
-  SeeedOled.drawBitmap(SeeedLogo,1024);   // 1024 = 128 Pixels * 64 Pixels / 8
+  SeeedOled.drawBitmap((unsigned char*) SeeedLogo,1024);   // 1024 = 128 Pixels * 64 Pixels / 8
 
   setDisplayToOriginalState(5);
   
   SeeedOled.setInverseDisplay();          // Set Display to inverse mode
   SeeedOled.clearDisplay();               // clear the screen and set start position to top left corner
-  SeeedOled.drawBitmap(SeeedLogo,1024);   // 1024 = 128 Pixels * 64 Pixels / 8
+  SeeedOled.drawBitmap((unsigned char*) SeeedLogo,1024);   // 1024 = 128 Pixels * 64 Pixels / 8
 
   setDisplayToOriginalState(6);
   
   SeeedOled.clearDisplay();               // clear the screen and set start position to top left corner
-  SeeedOled.drawBitmap(SeeedLogo,1024);   // 1024 = 128 Pixels * 64 Pixels / 8
+  SeeedOled.drawBitmap((unsigned char*) SeeedLogo,1024);   // 1024 = 128 Pixels * 64 Pixels / 8
   SeeedOled.setHorizontalScrollProperties(Scroll_Left,4,7,Scroll_5Frames); //Set Scrolling properties to Scroll Left
   SeeedOled.activateScroll();             // Activate Scrolling
   delay(5000);
@@ -161,7 +161,7 @@ void loop()
   setDisplayToOriginalState(7);
 
   SeeedOled.clearDisplay();               // clear the screen and set start position to top left corner
-  SeeedOled.drawBitmap(SeeedLogo,1024);   // 1024 = 128 Pixels * 64 Pixels / 8
+  SeeedOled.drawBitmap((unsigned char*) SeeedLogo,1024);   // 1024 = 128 Pixels * 64 Pixels / 8
   SeeedOled.setHorizontalScrollProperties(Scroll_Right,4,7,Scroll_5Frames);  //Set the properties of Horizontal Scrool
   SeeedOled.activateScroll();             // Activate Scroll
   delay(5000);  


### PR DESCRIPTION
- Added 'const' keyword to SeeedLogo declaration to address error when compiling via 1.6.9 ( "variable 'SeeedLogo' must be const in order to be put into read-only section by means of '**attribute**((progmem))' ")
  FROM static unsigned char SeeedLogo[] PROGMEM  TO static const unsigned char SeeedLogo[] PROGMEM
- Added casting to type unsigned char\* when using the drawBitmap method to address error introduced by the required 'const' keyword for SeeedLogo PROGMEM use ( "invalid conversion from 'const unsigned char_' to 'unsigned char_' [-fpermissive]")
  FROM SeeedOled.drawBitmap(SeeedLogo,1024); TO SeeedOled.drawBitmap((unsigned char*) SeeedLogo,1024);
