### PR TITLE
Add support for Arduino 101

### DIFF
--- a/SeeedOLED.cpp
+++ b/SeeedOLED.cpp
@@ -25,7 +25,7 @@
 #include "Wire.h"
 #include "SeeedOLED.h"
 
-#if (defined(__AVR__) || defined(__SAMD21G18A__))
+#if (defined(__AVR__) || defined(__SAMD21G18A__) || defined(ARDUINO_ARCH_ARC32))
 #include <avr/pgmspace.h>
 #else
 #include <pgmspace.h>


### PR DESCRIPTION
Previously, compiling the library for Arduino/Genuino 101 would fail:
```
E:\electronics\arduino\libraries\OLED_Display_128X64-master\SeeedOLED.cpp:31:22: fatal error: pgmspace.h: No such file or directory

 #include <pgmspace.h>

                      ^
```

I don't own the hardware to verify the library actually works on 101 but this does fix the compilation error and does no harm.

The `ARDUINO_ARCH_ARC32` identifying macro I used is defined in the Intel Curie hardware package's platform.txt. If anyone knows of a more low level macro please let me know.